### PR TITLE
Optimize Dockerfile by moving project files after dependency layer

### DIFF
--- a/{{cookiecutter.project_name}}/Dockerfile
+++ b/{{cookiecutter.project_name}}/Dockerfile
@@ -1,21 +1,24 @@
 FROM python:{{cookiecutter.python_version}}
 
-# add user
-RUN useradd -r -s /bin/bash bob
+# establish working folder
+WORKDIR /app
 
-# add project
-ADD . /app
+# add user and give ownership to workdir
+RUN useradd -r -s /bin/bash bob
 RUN chown -R bob:bob /app
 
 USER bob
 
 # set home & current env
 ENV HOME /app
-WORKDIR /app
 ENV PATH="/app/.local/bin:${PATH}"
 
 # install dependencies
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt --user
+
+# add project
+ADD . /app
 
 # start wsgi server
 ENTRYPOINT ["uwsgi"]


### PR DESCRIPTION
In keeping with good Dockerfile practices, things that change the most should be placed at the bottom of the `Dockerfile` so that you can optimize Docker layer caching. It is a best practice to establish dependencies before adding other code that might change so that every change to your source files doesn't rebuild all of the dependencies.

I've moved the installation of the Python dependencies before adding the application code to establish this cached dependency layer. The makes future docker builds execute significantly faster.